### PR TITLE
Reproduces sitemap extra slashes bug

### DIFF
--- a/app/routes/_extra-slahes+/_layout.tsx
+++ b/app/routes/_extra-slahes+/_layout.tsx
@@ -1,0 +1,5 @@
+import { Outlet } from "@remix-run/react";
+
+export default function Layout() {
+  return <div><Outlet /></div>
+}

--- a/app/routes/_extra-slahes+/extra-slashes.tsx
+++ b/app/routes/_extra-slahes+/extra-slashes.tsx
@@ -1,0 +1,7 @@
+export default function ExtraSlashesRoute() {
+  return (
+    <div>
+      <h1>Extra Slashes Route</h1>
+    </div>
+  );
+}

--- a/app/routes/sitemap[.]xml.ts
+++ b/app/routes/sitemap[.]xml.ts
@@ -3,11 +3,12 @@ import { routes } from "@remix-run/dev/server-build";
 import type { LoaderFunctionArgs } from "@remix-run/node";
 
 export function loader({ request }: LoaderFunctionArgs) {
+  console.log('routes', routes)
   // Remove the _layout parent id from the routes
   // Uncomment to fix extra slashes in the sitemap
   // for (const key in routes) {
   //   const route = routes[key];
-  //   if (route.parentId?.includes('_layout')) {
+  //   if (route.parentId?.endsWith('_layout')) {
   //     route.parentId = routes[route.parentId].parentId;
   //   }
   // }

--- a/app/routes/sitemap[.]xml.ts
+++ b/app/routes/sitemap[.]xml.ts
@@ -1,8 +1,16 @@
+import { generateSitemap } from "@nasa-gcn/remix-seo";
 import { routes } from "@remix-run/dev/server-build";
 import type { LoaderFunctionArgs } from "@remix-run/node";
-import { generateSitemap } from "@nasa-gcn/remix-seo";
 
 export function loader({ request }: LoaderFunctionArgs) {
+  // Remove the _layout parent id from the routes
+  // Uncomment to fix extra slashes in the sitemap
+  // for (const key in routes) {
+  //   const route = routes[key];
+  //   if (route.parentId?.includes('_layout')) {
+  //     route.parentId = routes[route.parentId].parentId;
+  //   }
+  // }
   return generateSitemap(request, routes, {
     siteUrl: "https://balavishnuvj.com",
   });


### PR DESCRIPTION
This bug appears when using a folder  like `_extra-slashes+` and a layout (`_extra-slashes+/_layout.tsx`).
So for reproduces the bug I created a new route `extra-slashes` with this folder structure: 

```
├── routes
│   ├── _extra-slashes+
│   │   ├── _layout.tsx
│   │   ├── extra-slahes.tsx
│   ├── _index.tsx
│   ├── sitemap[.].xml
```

Then the `build.routes` are: 
```ts
{
  root: {
    id: 'root',
    parentId: undefined,
    path: '',
    index: undefined,
    caseSensitive: undefined,
    module: { default: [Getter], links: [Getter] }
  },
  'routes/_extra-slahes+/_layout': {
    id: 'routes/_extra-slahes+/_layout',
    parentId: 'root',
    path: undefined,
    index: undefined,
    caseSensitive: undefined,
    module: { default: [Getter] }
  },
  'routes/_extra-slahes+/extra-slashes': {
    id: 'routes/_extra-slahes+/extra-slashes',
    parentId: 'routes/_extra-slahes+/_layout',
    path: 'extra-slashes',
    index: undefined,
    caseSensitive: undefined,
    module: { default: [Getter] }
  },
  ...
}
```

The problem is `build.routes['routes/_extra-slahes+/extra-slashes'].parentId` points to `routes/_extra-slahes+/_layout` instead of `root`.

To fix the "bug" I added this code to modify `build.routes` before generating the sitemap : 
```ts
// sitemap[.]xml.ts
import { generateSitemap } from "@nasa-gcn/remix-seo";
import { routes } from "@remix-run/dev/server-build";
import type { LoaderFunctionArgs } from "@remix-run/node";

export function loader({ request }: LoaderFunctionArgs) {
  // Remove the _layout parent id from the routes
  for (const key in routes) {
    const route = routes[key];
    if (route.parentId?.endsWith('_layout')) {
      route.parentId = routes[route.parentId].parentId;
    }
  }
  return generateSitemap(request, routes, {
    siteUrl: "https://balavishnuvj.com",
  });
}
```